### PR TITLE
fix(app): fix wrong attributes in app.py in loading labels

### DIFF
--- a/eiseg/app.py
+++ b/eiseg/app.py
@@ -724,7 +724,7 @@ class APP_EISeg(QMainWindow, Ui_EISeg):
             return
         labelJson = open(file_path, "r").read()
         self.controller.readLabel(file_path)
-        print("Loaded label list:", self.controller.labelList.list)
+        print("Loaded label list:", self.controller.labelList.labelList)
         self.refreshLabelList()
         self.settings.setValue("label_list_file", file_path)
 

--- a/eiseg/app.py
+++ b/eiseg/app.py
@@ -1644,7 +1644,7 @@ class APP_EISeg(QMainWindow, Ui_EISeg):
         grid_num = int(self.gridSelect.currentText())
         self.gridTable.setColumnCount(grid_num)
         self.gridTable.setRowCount(grid_num)
-        if self.image:
+        if self.image is not None:
             self.imagesGrid = slide_out(self.image, grid_num, grid_num)
             # self.controller.image = self.imagesGrid[0]
             self.controller.setImage(self.imagesGrid[0])

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+ROOT=`cd "$(dirname ${BASH_SOURCE[0]})" && pwd`
+
+echo "ROOT : $ROOT"
+
+export PYTHONPATH=$PYTHONPATH:$ROOT/eiseg


### PR DESCRIPTION
1. fix wrong attributes in loading labels:
```python
print("Loaded label list:", self.controller.labelList.list)
```

should be

```python
print("Loaded label list:", self.controller.labelList.labelList)
```

Wrong attributes cause Qt window crash when loading different labels